### PR TITLE
Simplify shrine asset handling

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,13 +1,6 @@
 ---
 import '../styles/global.css';
 
-interface FontPreload {
-  href: string;
-  type: string;
-  as?: string;
-  crossorigin?: string;
-}
-
 interface Props {
   title: string;
   description: string;
@@ -15,9 +8,6 @@ interface Props {
   favicon?: string;
   appleTouchIcon?: string;
   lang?: string;
-  fontFaceCss?: string;
-  fontPreloads?: FontPreload[];
-  audioPreloads?: string[];
 }
 
 const {
@@ -27,9 +17,6 @@ const {
   favicon,
   appleTouchIcon,
   lang = 'en',
-  fontFaceCss,
-  fontPreloads = [],
-  audioPreloads = [],
 } = Astro.props as Props;
 ---
 <!DOCTYPE html>
@@ -50,19 +37,6 @@ const {
     <meta property="og:image" content={ogImage} />
     {favicon && <link rel="icon" type="image/png" href={favicon} />}
     {appleTouchIcon && <link rel="apple-touch-icon" href={appleTouchIcon} />}
-    {fontPreloads.map((font) => (
-      <link
-        rel="preload"
-        href={font.href}
-        as={font.as ?? 'font'}
-        type={font.type}
-        crossorigin={font.crossorigin ?? 'anonymous'}
-      />
-    ))}
-    {audioPreloads.map((href) => (
-      <link rel="preload" href={href} as="audio" />
-    ))}
-    {fontFaceCss && <style is:global set:html={fontFaceCss} />}
     <slot name="head" />
   </head>
   <body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,16 +7,12 @@ import soundboardScript from '../scripts/soundboard.ts?url';
 const title = 'The Shrine: svenpanel 🔴 next generation';
 const description = 'Gude Laune! Feierei Alter! Abfahrt auch auf dem Telefon und Tablet. Auch offline. Obergeil.';
 const placeholders = Array.from({ length: 6 });
-const site = Astro.site ?? new URL('http://localhost:4321/');
-const ogImage = new URL('og_image.png', site).toString();
-const asset = (path: string) => new URL(path, site).pathname;
-const fontFaceCss = `@font-face {\n  font-family: "Keania One";\n  font-style: normal;\n  font-weight: 400;\n  font-display: swap;\n  src:\n    local("Keania One"),\n    local("KeaniaOne-Regular"),\n    url(${new URL('fonts/Keania_One/KeaniaOne-Regular.woff2', site).pathname}) format('woff2'),\n    url(${new URL('fonts/Keania_One/KeaniaOne-Regular.ttf', site).pathname}) format('truetype');\n  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;\n}`;
-const favicon = asset('icon.png');
-const fontPreloads = [
-  { href: asset('fonts/Keania_One/KeaniaOne-Regular.woff2'), type: 'font/woff2' },
-  { href: asset('fonts/Keania_One/KeaniaOne-Regular.ttf'), type: 'font/ttf' },
-];
-const audioPreloads = sounds.map((sound) => asset(`sounds/${sound.file}`));
+const base = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : `${import.meta.env.BASE_URL}/`;
+const assetPath = (path: string) => `${base}${path.replace(/^\//, '')}`;
+const site = Astro.site ?? new URL(base, 'http://localhost:4321');
+const toAbsolute = (path: string) => new URL(path, site).toString();
+const ogImage = toAbsolute(assetPath('og_image.png'));
+const favicon = assetPath('icon.png');
 ---
 <BaseLayout
   title={title}
@@ -24,9 +20,6 @@ const audioPreloads = sounds.map((sound) => asset(`sounds/${sound.file}`));
   ogImage={ogImage}
   favicon={favicon}
   appleTouchIcon={favicon}
-  fontFaceCss={fontFaceCss}
-  fontPreloads={fontPreloads}
-  audioPreloads={audioPreloads}
 >
   <section class="index">
     <div class="index__shrine">
@@ -102,7 +95,7 @@ welcome.</a>
       <p>You can still play every quote manually. Tap a filename to open it in your browser.</p>
       <ul>
         {sounds.map((sound) => (
-          <li><a href={asset(`sounds/${sound.file}`)}>{sound.name}</a></li>
+          <li><a href={assetPath(`sounds/${sound.file}`)}>{sound.name}</a></li>
         ))}
       </ul>
       {grooves.length > 0 && (
@@ -110,7 +103,7 @@ welcome.</a>
           <h2>Grooves</h2>
           <ul>
             {grooves.map((groove) => (
-              <li><a href={asset(`grooves/${groove.file}`)}>{groove.name}</a></li>
+              <li><a href={assetPath(`grooves/${groove.file}`)}>{groove.name}</a></li>
             ))}
           </ul>
         </>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,15 @@
+@font-face {
+  font-family: "Keania One";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src:
+    url("/fonts/Keania_One/KeaniaOne-Regular.woff2") format("woff2"),
+    url("/fonts/Keania_One/KeaniaOne-Regular.ttf") format("truetype");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122,
+    U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
 :root {
   --color-background: hsl(0, 0%, 0%);
   --color-primary: hsl(0, 0%, 100%);


### PR DESCRIPTION
## Summary
- move the Keania font-face definition into the global stylesheet
- remove the audio/font preload plumbing from the base layout
- simplify index page asset resolution while keeping metadata intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5ff001c84832d9eafa62d1661d17d