### PR TITLE
Convert soundboard tiles to buttons

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,11 +30,10 @@ const favicon = assetPath('icon.png');
         </span>
       </h1>
       <main class="index__sounds">
-        {sounds.map((sound, index) => (
-          <article
+        {sounds.map((sound) => (
+          <button
+            type="button"
             class="index__sound"
-            tabindex={index + 1}
-            role="button"
             aria-label={sound.name}
             data-sound-file={sound.file}
           >
@@ -42,7 +41,7 @@ const favicon = assetPath('icon.png');
             <div>
               <span class="index__sound-knob" aria-hidden="true"></span>
             </div>
-          </article>
+          </button>
         ))}
         {placeholders.map((_, index) => (
           <div class="index__sound" hidden aria-hidden="true" data-placeholder={index}></div>

--- a/src/scripts/soundboard.ts
+++ b/src/scripts/soundboard.ts
@@ -8,7 +8,7 @@ function resolveAsset(path: string): string {
 
 function handleSoundboard(): void {
   const container = document.querySelector('[data-sound-container]') ?? document.body;
-  const tiles = document.querySelectorAll<HTMLElement>('[data-sound-file]');
+  const tiles = document.querySelectorAll<HTMLButtonElement>('[data-sound-file]');
 
   tiles.forEach((tile) => {
     const file = tile.dataset.soundFile;
@@ -28,13 +28,6 @@ function handleSoundboard(): void {
     };
 
     tile.addEventListener('click', play);
-    tile.addEventListener('keydown', (event) => {
-      if (event.defaultPrevented) return;
-      if (event.key === 'Enter' || event.key === ' ') {
-        event.preventDefault();
-        play();
-      }
-    });
   });
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -150,6 +150,8 @@ body {
   border: none;
   color: inherit;
   text-decoration: none;
+  font: inherit;
+  appearance: none;
 }
 
 .index__sound:focus {


### PR DESCRIPTION
## Summary
- replace the soundboard tile markup with native buttons for built-in keyboard activation
- normalize the .index__sound button styles so the visual design stays unchanged
- remove the redundant keydown handler now that button clicks cover keyboard input

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6902805e8424832db10a694aac8092b0